### PR TITLE
Update README.md to link to Spring AI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you cannot use the official version at https://www.atlassian.com/platform/remote-mcp-server, you can use this simple custom implementation!
 
-Implemented with [Spring AI](https://spring.io/projects/spring-ai) using [Confluence Cloud API](https://developer.atlassian.com/cloud/confluence/rest/v3/intro/#about) and [Jira Cloud API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#about)
+Implemented with [Spring AI](https://docs.spring.io/spring-ai/reference/index.html) using [Confluence Cloud API](https://developer.atlassian.com/cloud/confluence/rest/v3/intro/#about) and [Jira Cloud API](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#about)
 
 ## Requirements
 


### PR DESCRIPTION
The previous link to https://spring.io/projects/spring-ai ends up linking to a few pages that 404 (e.g.: [Tools/Function Calling](https://docs.spring.io/spring-ai/reference/api/functions.html)).

This replaces it with the overview page of the Spring AI docs: https://docs.spring.io/spring-ai/reference/index.html. This page has valid links (e.g.: [Tools/Function Calling](https://docs.spring.io/spring-ai/reference/api/tools.html)).