### PR TITLE
Move to the new API path for `getJiraTickets`

### DIFF
--- a/src/main/kotlin/com/rogervinas/tools/JiraTool.kt
+++ b/src/main/kotlin/com/rogervinas/tools/JiraTool.kt
@@ -46,7 +46,7 @@ class JiraTool(private val restTemplate: RestTemplate) {
             val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
             val fromDateStr = fromDate.format(formatter)
             val toDateStr = toDate.format(formatter)
-            val uri = UriComponentsBuilder.fromUriString("/rest/api/3/search")
+            val uri = UriComponentsBuilder.fromUriString("/rest/api/3/search/jql")
                 .queryParam(
                     "jql",
                     "project=\"$project\" AND created >= \"$fromDateStr\" AND created <= \"$toDateStr\" ORDER BY created ASC"


### PR DESCRIPTION
Fixing the error when getting JIRA tickets as the API moved.
```
org.springframework.web.client.HttpClientErrorException$Gone: 410 Gone on GET request for "https://foo.atlassian.net/rest/api/3/search": "{"errorMessages":["The requested API has been removed. Please migrate to the /rest/api/3/search/jql API. A full migration guideline is available at https://developer.atlassian.com/changelog/#CHANGE-2046"],"errors":{}}"
```